### PR TITLE
Update datetime for deadline and event to LocalDate objects

### DIFF
--- a/src/main/java/Duke/Command/Command.java
+++ b/src/main/java/Duke/Command/Command.java
@@ -1,12 +1,15 @@
 package Duke.Command;
 
-import Duke.Exception.NoDateTimeSpecifiedException;
+import Duke.Exception.InvalidDateTimeSpecifiedException;
 import Duke.Exception.NoTaskSpecifiedException;
 import Duke.Task.*;
 import Duke.Ui.Ui;
 
 import java.io.FileWriter;
 import java.io.IOException;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
 
 public class Command {
 
@@ -20,23 +23,23 @@ public class Command {
 
 
     public static Task createDeadline(String removedInstructionString)
-            throws NoTaskSpecifiedException, NoDateTimeSpecifiedException {
+            throws NoTaskSpecifiedException, InvalidDateTimeSpecifiedException {
         //TODO need to catch lack of by here.
         String taskDescription;
-        String byDate;
+        String byDateString;
+        LocalDate byDate;
         try {
             String dateIndicator = "/by";
             String[] deadlineContents = removedInstructionString.split(dateIndicator, 2);
             taskDescription = deadlineContents[0].trim();
-            byDate = deadlineContents[1].trim();
-        } catch (ArrayIndexOutOfBoundsException e) {
-            throw new NoDateTimeSpecifiedException();
+            byDateString = deadlineContents[1].trim();
+            byDate = LocalDate.parse(byDateString);
+
+        } catch (ArrayIndexOutOfBoundsException | DateTimeParseException e) {
+            throw new InvalidDateTimeSpecifiedException();
         }
         if (taskDescription.isEmpty()) {
             throw new NoTaskSpecifiedException();
-        }
-        if (byDate.isEmpty()) {
-            throw new NoDateTimeSpecifiedException();
         }
 
         return new Deadline(taskDescription, byDate);
@@ -110,8 +113,8 @@ public class Command {
                     task = createDeadline(removedInstructionString);
                 } catch (NoTaskSpecifiedException e) {
                     System.out.println("Please indicate the task for deadline.");
-                } catch (NoDateTimeSpecifiedException e) {
-                    System.out.println("Please indicate the end date for this deadline");
+                } catch (InvalidDateTimeSpecifiedException e) {
+                    System.out.println("Please indicate the end date for this deadline in yyyy-mm-dd format");
                 }
                 break;
             case "event":
@@ -119,8 +122,8 @@ public class Command {
                     task = createEvent(removedInstructionString);
                 } catch (NoTaskSpecifiedException e) {
                     System.out.println("Please indicate the task for event.");
-                } catch (NoDateTimeSpecifiedException e) {
-                    System.out.println("Please indicate the start date and end date for this event.");
+                } catch (InvalidDateTimeSpecifiedException e) {
+                    System.out.println("Please indicate the start date and end date in yyyy-mm-dd format for this event.");
                 }
                 break;
             default:
@@ -172,27 +175,30 @@ public class Command {
         ui.printLine();
     }
 
-    public static Task createEvent(String removedInstructionString) throws NoTaskSpecifiedException, NoDateTimeSpecifiedException {
+    public static Task createEvent(String removedInstructionString) throws NoTaskSpecifiedException, InvalidDateTimeSpecifiedException {
         String taskDescription;
-        String fromDate;
-        String toDate;
+        String fromDateString;
+        String toDateString;
         String startDateIndicator = "/from";
         String endDateIndicator = "/to";
+        LocalDate fromDate;
+        LocalDate toDate;
         String eventSplitNotation = startDateIndicator + "|" + endDateIndicator;
         String[] eventContents = removedInstructionString.split(eventSplitNotation);
         try {
             taskDescription = eventContents[0].trim();
-            fromDate = eventContents[1].trim();
-            toDate = eventContents[2].trim();
-        } catch (ArrayIndexOutOfBoundsException e) {
-            throw new NoDateTimeSpecifiedException();
+            fromDateString = eventContents[1].trim();
+            toDateString = eventContents[2].trim();
+            fromDate = LocalDate.parse(fromDateString);
+            toDate = LocalDate.parse(toDateString);
+            
+        } catch (ArrayIndexOutOfBoundsException | DateTimeParseException e) {
+            throw new InvalidDateTimeSpecifiedException();
         }
         if (taskDescription.isEmpty()) {
             throw new NoTaskSpecifiedException();
         }
-        if (fromDate.isEmpty() | toDate.isEmpty()) {
-            throw new NoDateTimeSpecifiedException();
-        }
+     
         return new Event(taskDescription, fromDate, toDate);
     }
 

--- a/src/main/java/Duke/Exception/InvalidDateTimeSpecifiedException.java
+++ b/src/main/java/Duke/Exception/InvalidDateTimeSpecifiedException.java
@@ -1,0 +1,4 @@
+package Duke.Exception;
+
+public class InvalidDateTimeSpecifiedException extends Exception {
+}

--- a/src/main/java/Duke/Exception/NoDateTimeSpecifiedException.java
+++ b/src/main/java/Duke/Exception/NoDateTimeSpecifiedException.java
@@ -1,4 +1,0 @@
-package Duke.Exception;
-
-public class NoDateTimeSpecifiedException extends Exception {
-}

--- a/src/main/java/Duke/Storage/Storage.java
+++ b/src/main/java/Duke/Storage/Storage.java
@@ -1,7 +1,7 @@
 package Duke.Storage;
 
 import Duke.Command.Command;
-import Duke.Exception.NoDateTimeSpecifiedException;
+import Duke.Exception.InvalidDateTimeSpecifiedException;
 import Duke.Exception.NoTaskSpecifiedException;
 import Duke.Task.Task;
 import Duke.Task.TaskList;
@@ -45,14 +45,14 @@ public class Storage {
             case ("D"):
                 try {
                     task = Command.createDeadline(messageFragments[2]);
-                } catch (NoTaskSpecifiedException | NoDateTimeSpecifiedException e) {
+                } catch (NoTaskSpecifiedException | InvalidDateTimeSpecifiedException e) {
                     System.out.println("Failed loading Deadline. Deadline will be deleted.");
                 }
                 break;
             case ("E"):
                 try {
                     task = Command.createEvent(messageFragments[2]);
-                } catch (NoTaskSpecifiedException | NoDateTimeSpecifiedException e) {
+                } catch (NoTaskSpecifiedException | InvalidDateTimeSpecifiedException e) {
                     System.out.println("Failed loading Event. Event will be deleted.");
                 }
                 break;

--- a/src/main/java/Duke/Task/Deadline.java
+++ b/src/main/java/Duke/Task/Deadline.java
@@ -1,9 +1,12 @@
 package Duke.Task;
 
-public class Deadline extends Task {
-    protected String endDate;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
-    public Deadline(String description, String endDate) {
+public class Deadline extends Task {
+    protected LocalDate endDate;
+
+    public Deadline(String description, LocalDate endDate) {
         super(description);
         this.endDate = endDate;
         taskType = "Deadline";
@@ -13,12 +16,14 @@ public class Deadline extends Task {
     @Override
     public String convertToSaveFormat() {
         String doneMarker = isDone ? "1" : "0";
-        return symbol + " | " + doneMarker + " | " + description + "/by " + endDate;
+        String endDateString = endDate.format(DateTimeFormatter.ofPattern("MMM d yyyy"));
+        return symbol + " | " + doneMarker + " | " + description + "/by " + endDateString;
     }
 
     @Override
     public String toString() {
-        return "\t[D]" + super.toString() + " (by: " + this.endDate + ")";
+        String endDateString = endDate.format(DateTimeFormatter.ofPattern("MMM d yyyy"));
+        return "\t[D]" + super.toString() + " (by: " + endDateString + ")";
     }
 
 }

--- a/src/main/java/Duke/Task/Event.java
+++ b/src/main/java/Duke/Task/Event.java
@@ -1,9 +1,13 @@
 package Duke.Task;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+
 public class Event extends Task {
-    protected String startDateTime;
-    protected String endDateTime;
-    public Event(String description, String startDateTime, String endDateTime) {
+    protected LocalDate startDateTime;
+    protected LocalDate endDateTime;
+    public Event(String description, LocalDate startDateTime, LocalDate endDateTime) {
         super(description);
         this.startDateTime = startDateTime;
         this.endDateTime = endDateTime;


### PR DESCRIPTION
Change the format of dateTime to LocalDate objects from string for deadline and event.

The following error has been updated:
from "NoDateTimeSpecifiedException" to "InvalidDateTimeSpecifiedException".